### PR TITLE
Container name for env data table, process name for process table

### DIFF
--- a/cassandra/data/benchflow.cql
+++ b/cassandra/data/benchflow.cql
@@ -45,6 +45,7 @@ CREATE TABLE io_data (
 CREATE TABLE environment_data (
   environment_data_id uuid,
   container_id text,
+  container_name text,
   host_id text,
   read_time text,
   cpu_percpu_usage list<bigint>,
@@ -57,7 +58,7 @@ CREATE TABLE environment_data (
   network_interfaces map<text, uuid>,
   experiment_id text,
   trial_id text,
-  PRIMARY KEY ((experiment_id, trial_id), container_id, host_id, environment_data_id)
+  PRIMARY KEY ((experiment_id, trial_id), host_id, container_id, environment_data_id)
 );
 
 CREATE TABLE network_interface_data (
@@ -81,6 +82,7 @@ CREATE TABLE network_interface_data (
 CREATE TABLE process (
   source_process_instance_id text,
   process_definition_id text,
+  process_name text,
   start_time timestamp,
   duration bigint,
   end_time timestamp,


### PR DESCRIPTION
Additional columns for Cassandra database, see issue https://github.com/benchflow/analysers/issues/100 and pull https://github.com/benchflow/analysers/pull/101
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/benchflow/docker-images/pull/23%23discussion_r77617522%22%2C%20%22https%3A//github.com/benchflow/docker-images/pull/23%23discussion_r77623987%22%2C%20%22https%3A//github.com/benchflow/docker-images/pull/23%23discussion_r77693871%22%2C%20%22https%3A//github.com/benchflow/docker-images/pull/23%23discussion_r77773566%22%2C%20%22https%3A//github.com/benchflow/docker-images/pull/23%23discussion_r77802943%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%200d8c656c56d8abd38f188106d4c814953170d42e%20cassandra/data/benchflow.cql%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/docker-images/pull/23%23discussion_r77617522%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20%60container_name%60%20is%20not%20here%20too.%22%2C%20%22created_at%22%3A%20%222016-09-06T11%3A31%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40VincenzoFerme%20We%20are%20already%20clustering%20by%20container%20id%2C%20we%20don%27t%20need%20to%20do%20it%20by%20container%20name%20as%20well%22%2C%20%22created_at%22%3A%20%222016-09-06T12%3A26%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8819678%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Cerfoglg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5BThis%20query%5D%28https%3A//github.com/benchflow/analysers/blob/dev/analysers/commons/commons.py%23L179%29%20would%20be%20slower%20if%20you%20don%27t%20cluster%20also%20for%20%60container_name%60%22%2C%20%22created_at%22%3A%20%222016-09-06T18%3A39%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40VincenzoFerme%20We%20are%20already%20partitioning%20by%20trial%20id%20and%20experiment%20id%2C%20and%20clustering%20by%20container%20and%20host.%20The%20data%20are%20already%20spatially%20located%20closed%20to%20each%20other%20at%20this%20point%2C%20adding%20container%20name%20to%20it%20is%20redundant%20at%20this%20point%2C%20and%20we%20are%20just%20increasing%20the%20primary%20key%20size%20for%20little%20gain%20%28plus%2C%20primary%20keys%20shouldn%27t%20be%20made%20too%20large%20if%20possible%29%22%2C%20%22created_at%22%3A%20%222016-09-07T07%3A43%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8819678%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Cerfoglg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-09-07T11%3A17%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20cassandra/data/benchflow.cql%3AL58-65%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 0d8c656c56d8abd38f188106d4c814953170d42e cassandra/data/benchflow.cql 13'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/docker-images/pull/23#discussion_r77617522'>File: cassandra/data/benchflow.cql:L58-65</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> Why `container_name` is not here too.
- <a href='https://github.com/Cerfoglg'><img border=0 src='https://avatars.githubusercontent.com/u/8819678?v=3' height=16 width=16'></a> @VincenzoFerme We are already clustering by container id, we don't need to do it by container name as well
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> [This query](https://github.com/benchflow/analysers/blob/dev/analysers/commons/commons.py#L179) would be slower if you don't cluster also for `container_name`
- <a href='https://github.com/Cerfoglg'><img border=0 src='https://avatars.githubusercontent.com/u/8819678?v=3' height=16 width=16'></a> @VincenzoFerme We are already partitioning by trial id and experiment id, and clustering by container and host. The data are already spatially located closed to each other at this point, adding container name to it is redundant at this point, and we are just increasing the primary key size for little gain (plus, primary keys shouldn't be made too large if possible)

<a href='https://www.codereviewhub.com/benchflow/docker-images/pull/23?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/benchflow/docker-images/pull/23?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/docker-images/pull/23'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
